### PR TITLE
Fix slowdown by removing debug logging

### DIFF
--- a/jransformers/nano_gpt/model.py
+++ b/jransformers/nano_gpt/model.py
@@ -182,7 +182,6 @@ class GPT(eqx.Module):
         inference: bool = False,
     ) -> Float[Array, "n_tokens vocab_size"]:
         x = self.transformer(key, tokens, inference=inference)
-        print(f"{inference=} {tokens=}")
         if not inference:
             logits = jax.vmap(self.lm_head)(x)  # (n_tokens, vocab_size)
         else:


### PR DESCRIPTION
## Summary
- eliminate verbose print statement from `GPT.__call__`

## Testing
- `python -m py_compile jransformers/nano_gpt/*.py jransformers/attention.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a8006e8883249d7de697888e7731