### PR TITLE
Fix sampling and attention edge cases

### DIFF
--- a/jransformers/attention.py
+++ b/jransformers/attention.py
@@ -19,6 +19,8 @@ def scaled_dot_product(
     attn_logits = logits / math.sqrt(d_k)
     if mask is not None:
         logits = jnp.where(mask == 0, jnp.finfo(logits.dtype).min, attn_logits)
+    else:
+        logits = attn_logits
     attention = jax.nn.softmax(logits, axis=-1)
     values = jnp.matmul(attention, v)
     return values, attention

--- a/jransformers/nano_gpt/model.py
+++ b/jransformers/nano_gpt/model.py
@@ -234,8 +234,10 @@ class GPT(eqx.Module):
                 min_value = v[0, -1]
                 logits = jnp.where(logits < min_value, -jnp.inf, logits)
                     
-            probs = jax.nn.softmax(logits, axis=-1)            
-            next_token = jax.random.categorical(subkey, probs[0])
+            # jax.random.categorical expects log-probabilities. The logits are
+            # already unnormalized log-probabilities, so we pass them directly
+            # after applying temperature scaling and optional top-k filtering.
+            next_token = jax.random.categorical(subkey, logits[0])
             print(f"Generated token {i+1}/{max_new_tokens}: {next_token}")
             tokens = jnp.append(tokens, next_token)
             


### PR DESCRIPTION
## Summary
- ensure scaled dot-product attention always applies sqrt(d_k)
- pass logits directly to `jax.random.categorical` during generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b6f627b883249f953e643553c60c