### PR TITLE
Align training defaults with nanoGPT

### DIFF
--- a/jransformers/nano_gpt/config.py
+++ b/jransformers/nano_gpt/config.py
@@ -14,28 +14,30 @@ class GPTConfig:
 @dataclass
 class TrainConfig:
     """Training configuration"""
-    num_steps: int = 500
-    batch_size: int = 1024
+    # Settings adapted from nanoGPT's tiny Shakespeare configuration
+    num_steps: int = 5000
+    batch_size: int = 64
+    # Use the original output directory path
     out_dir = '/mnt/nvme9n1/huggingface/hub/out/'
-    eval_interval = 100
-    log_interval = 1
+    eval_interval = 250
+    log_interval = 10
     eval_iters = 200
-    eval_only = False # if True, script exits right after the first eval
-    always_save_checkpoint = True # if True, always save a checkpoint after each eval
-    init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'    
+    eval_only = False  # if True, script exits right after the first eval
+    always_save_checkpoint = False
+    init_from = 'scratch'  # 'scratch' or 'resume' or 'gpt2*'
 
-    gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
+    gradient_accumulation_steps = 1  # nanoGPT uses no accumulation here
 
-    learning_rate = 1e-4 # max learning rate
+    learning_rate = 1e-3  # max learning rate
 
     weight_decay = 1e-1
     beta1 = 0.9
-    beta2 = 0.95
-    grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0
+    beta2 = 0.99
+    grad_clip = 1.0  # clip gradients at this value, or disable if == 0.0
     # learning rate decay settings
-    decay_lr = True # whether to decay the learning rate
-    warmup_iters = 2000 # how many steps to warm up for
-    lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
-    min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla    
+    decay_lr = True  # whether to decay the learning rate
+    warmup_iters = 100
+    lr_decay_iters = 5000
+    min_lr = 1e-4
     
 


### PR DESCRIPTION
## Summary
- set TinyShakespeare hyperparameters taken from nanoGPT
- revert out_dir to original path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c16eb8308324b16d3019ca8fb4d2