### PR TITLE
Add type hints across repo

### DIFF
--- a/jransformers/attention.py
+++ b/jransformers/attention.py
@@ -3,6 +3,7 @@ import equinox as eqx
 import jax
 import math
 
+from typing import Optional, Tuple
 
 from jax import numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray
@@ -12,8 +13,8 @@ def scaled_dot_product(
     q: Float[Array, "... dims seq_len"],
     k: Float[Array, "... dims seq_len"],
     v: Float[Array, "... dims seq_len"],
-    mask=None,
-):
+    mask: Optional[Array] = None,
+) -> Tuple[Float[Array, "... seq_q dims"], Float[Array, "... seq_q seq_k"]]:
     d_k = q.shape[-1]
     logits = einops.einsum(q, k, "... seq_q dims, ... seq_k dims -> ... seq_q seq_k")
     attn_logits = logits / math.sqrt(d_k)
@@ -26,7 +27,7 @@ def scaled_dot_product(
     return values, attention
 
 
-def expand_mask(mask):
+def expand_mask(mask: Array) -> Array:
     assert mask.ndim >= 2, "mask must be atleast 2 dim"
     if mask.ndim == 3:
         mask = jnp.expand_dims(mask, axis=1)
@@ -43,7 +44,7 @@ class MultiHeadAttention(eqx.Module):
     qkv_proj: eqx.nn.Linear
     output_proj: eqx.nn.Linear
 
-    def __init__(self, key: PRNGKeyArray, n_embed: int, n_heads: int):
+    def __init__(self, key: PRNGKeyArray, n_embed: int, n_heads: int) -> None:
         self.n_embed = n_embed
         self.n_heads = n_heads
 
@@ -64,7 +65,7 @@ class MultiHeadAttention(eqx.Module):
             key=key_proj,
         )
 
-    def __call__(self, x: Float[Array, "seq_len n_embed"], mask=None):
+    def __call__(self, x: Float[Array, "seq_len n_embed"], mask: Optional[Array] = None) -> Tuple[Float[Array, "seq_len n_embed"], Float[Array, "n_heads seq_len seq_len"]]:
         seq_len, n_embed = x.shape
         # a single projection layer, given the input produces Q, K, V matrices
         qkv = jax.vmap(self.qkv_proj)(x)

--- a/jransformers/nano_gpt/data.py
+++ b/jransformers/nano_gpt/data.py
@@ -1,15 +1,16 @@
-import jax 
+import jax
 from datasets import load_dataset
 from jax import numpy as jnp
 from jaxtyping import Float, Array, PRNGKeyArray
+from typing import Any, Dict, Generator, Tuple, Callable
 
 dataset_name = 'karpathy/tiny_shakespeare'
-_cached_vocab_info = None
+_cached_vocab_info: Dict[str, Any] | None = None
 
-def get_dataset():
+def get_dataset() -> Any:
     return load_dataset(dataset_name, trust_remote_code=True)
 
-def get_vocabulary_info():
+def get_vocabulary_info() -> Dict[str, Any]:
     global _cached_vocab_info
     if _cached_vocab_info is not None:
         return _cached_vocab_info
@@ -27,16 +28,18 @@ def get_vocabulary_info():
     _cached_vocab_info = {"stoi": stoi, "itos": itos, "vocab_size": vocab_size}
     return _cached_vocab_info
 
-def get_encoder():
+def get_encoder() -> Dict[str, int]:
     return get_vocabulary_info()["stoi"]
 
-def get_decoder():
+def get_decoder() -> Dict[int, str]:
     return get_vocabulary_info()["itos"]
 
-def get_vocab_size():
+def get_vocab_size() -> int:
     return get_vocabulary_info()["vocab_size"]
 
-def get_infinite_dataloader(key: PRNGKeyArray, split_type: str, batch_size: int, seq_len: int):
+def get_infinite_dataloader(
+    key: PRNGKeyArray, split_type: str, batch_size: int, seq_len: int
+) -> Generator[Tuple[jnp.ndarray, jnp.ndarray], None, None]:
     dataset_obj = get_dataset()
     assert split_type in dataset_obj.keys(), f"Split {split_type} not found in dataset"
     
@@ -46,8 +49,8 @@ def get_infinite_dataloader(key: PRNGKeyArray, split_type: str, batch_size: int,
     vocab_info = get_vocabulary_info()
     stoi = vocab_info["stoi"]
     
-    def encode_fn(s):
-        return [stoi[c] for c in s if c in stoi] 
+    def encode_fn(s: str) -> list[int]:
+        return [stoi[c] for c in s if c in stoi]
     
     data_encoded = encode_fn(full_text_for_split)
     n = len(data_encoded)

--- a/jransformers/nano_gpt/model.py
+++ b/jransformers/nano_gpt/model.py
@@ -5,7 +5,7 @@ from equinox import nn
 from dataclasses import dataclass
 from jax import numpy as jnp
 from jaxtyping import Integer, Float, Array, PRNGKeyArray
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from .. import attention
 from .config import GPTConfig
@@ -20,14 +20,14 @@ class SwiGLU(eqx.Module):
     b: Float[Array, "out_features"]
     c: Float[Array, "out_features"]
 
-    def __init__(self, key: PRNGKeyArray, in_features: int, out_features: int):
+    def __init__(self, key: PRNGKeyArray, in_features: int, out_features: int) -> None:
         k1, k2, k3, k4 = jax.random.split(key, 4)
         self.W = jax.random.normal(k1, (in_features, out_features))
         self.V = jax.random.normal(k2, (in_features, out_features))
         self.b = jax.random.normal(k3, (out_features,))
         self.c = jax.random.normal(k4, (out_features,))
 
-    def __call__(self, x):
+    def __call__(self, x: Float[Array, "... in_features"]) -> Float[Array, "... out_features"]:
         return jax.nn.swish(jnp.dot(x, self.W) + self.b) * (jnp.dot(x, self.V) + self.c)
 
 
@@ -37,7 +37,7 @@ class MLP(eqx.Module):
     c_proj: nn.Linear
     dropout: nn.Dropout
 
-    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig):
+    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig) -> None:
         key_fc, key_swiglu, key_proj, key_dropout = jax.random.split(key, 4)
 
         self.c_fc = nn.Linear(
@@ -73,7 +73,7 @@ class MLP(eqx.Module):
 class CasualSelfAttention(eqx.Module):
     mha: attention.MultiHeadAttention
 
-    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig):
+    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig) -> None:
         self.mha = attention.MultiHeadAttention(
             key=key, n_embed=model_config.n_embed, n_heads=model_config.n_head
         )
@@ -100,7 +100,7 @@ class Block(eqx.Module):
     ln_2: nn.LayerNorm
     mlp: MLP
 
-    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig):
+    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig) -> None:
         key_attn, key_mlp = jax.random.split(key, 2)
 
         self.ln_1 = nn.LayerNorm(model_config.n_embed, use_bias=model_config.bias)
@@ -127,7 +127,7 @@ class Transformer(eqx.Module):
     h: List[Block]
     ln_f: nn.LayerNorm
 
-    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig):
+    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig) -> None:
         te_key, pe_key, h_key = jax.random.split(key, 3)
 
         # token embeddings
@@ -172,7 +172,7 @@ class GPT(eqx.Module):
     transformer: Transformer
     lm_head: nn.Linear
 
-    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig):
+    def __init__(self, key: PRNGKeyArray, model_config: GPTConfig) -> None:
         key_transformer, key_lm_head = jax.random.split(key, 2)
 
         self.transformer = Transformer(key=key_transformer, model_config=model_config)

--- a/sample.py
+++ b/sample.py
@@ -7,6 +7,7 @@ import typer
 import pickle # Added import, ensure it's here
 
 from typing_extensions import Annotated
+from typing import Callable, Tuple
 from jransformers.nano_gpt import model, config, data
 
 
@@ -26,7 +27,7 @@ def get_latest_checkpoint(out_dir: str) -> str:
     return os.path.join(out_dir, ckpts[0])
 
 
-def read_char_tokenizer(out_dir: str):
+def read_char_tokenizer(out_dir: str) -> Tuple[Callable[[str], jnp.ndarray], Callable[[jnp.ndarray], str], int]:
     """Returns encoding and decoding functions based on the dataset's vocabulary.
     Loads from meta.pkl in out_dir.
     """


### PR DESCRIPTION
## Summary
- annotate functions in attention, data, model, train and sample modules with missing type hints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68466dfc29848324ae55ed530c83df71