### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add project root to sys.path so tests can import package
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,30 @@
+import jax
+import jax.numpy as jnp
+from jransformers import attention
+
+def test_scaled_dot_product():
+    key = jax.random.PRNGKey(0)
+    q = jax.random.normal(key, (2, 4))
+    key, subkey = jax.random.split(key)
+    k = jax.random.normal(subkey, (2, 4))
+    key, subkey = jax.random.split(key)
+    v = jax.random.normal(subkey, (2, 4))
+    values, attn = attention.scaled_dot_product(q[None, :], k[None, :], v[None, :])
+    assert values.shape == (1, 2, 4)
+    assert attn.shape == (1, 2, 2)
+    sums = attn.sum(axis=-1)
+    assert jnp.allclose(sums, jnp.ones_like(sums))
+
+def test_expand_mask():
+    mask = jnp.ones((2, 3))
+    out = attention.expand_mask(mask)
+    assert out.ndim == 4
+    assert out.shape[-2:] == (2, 3)
+
+def test_multi_head_attention_output_shape():
+    key = jax.random.PRNGKey(0)
+    mha = attention.MultiHeadAttention(key, n_embed=8, n_heads=2)
+    x = jax.random.normal(key, (3, 8))
+    values, attn = mha(x)
+    assert values.shape == (3, 8)
+    assert attn.shape == (2, 3, 3)

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -1,0 +1,13 @@
+import jax
+import jax.numpy as jnp
+from jransformers.nano_gpt import model, config
+
+
+def test_gpt_decode_shapes():
+    key = jax.random.PRNGKey(0)
+    gpt_conf = config.GPTConfig(block_size=8, n_layers=1, vocab_size=10, n_head=2, n_embed=8, dropout=0.0)
+    gpt = model.GPT(key, gpt_conf)
+    tokens = jnp.array([1, 2, 3])
+    key, subkey = jax.random.split(key)
+    out = gpt.decode(subkey, tokens, max_new_tokens=2)
+    assert out.shape[0] == len(tokens) + 2


### PR DESCRIPTION
## Summary
- add tests for attention utilities and GPT decoding
- allow tests to import repository

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846742f920c83249cf684b9905a2668